### PR TITLE
Feat/#1

### DIFF
--- a/iTunesApp/iTunesApp.xcodeproj/project.pbxproj
+++ b/iTunesApp/iTunesApp.xcodeproj/project.pbxproj
@@ -14,8 +14,19 @@
 		E5F569482DCE14A5007227A2 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = E5F569472DCE14A5007227A2 /* Kingfisher */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		E5D7D2342DD18F690094AC1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E51A319E2DCC9F73009043B0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E51A31A52DCC9F73009043B0;
+			remoteInfo = iTunesApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		E51A31A62DCC9F73009043B0 /* iTunesApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iTunesApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5D7D2302DD18F690094AC1C /* iTunesAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iTunesAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -37,6 +48,11 @@
 			path = iTunesApp;
 			sourceTree = "<group>";
 		};
+		E5D7D2312DD18F690094AC1C /* iTunesAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = iTunesAppTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +68,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E5D7D22D2DD18F690094AC1C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -59,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				E51A31A82DCC9F73009043B0 /* iTunesApp */,
+				E5D7D2312DD18F690094AC1C /* iTunesAppTests */,
 				E5F568492DCE1408007227A2 /* Frameworks */,
 				E51A31A72DCC9F73009043B0 /* Products */,
 			);
@@ -68,6 +92,7 @@
 			isa = PBXGroup;
 			children = (
 				E51A31A62DCC9F73009043B0 /* iTunesApp.app */,
+				E5D7D2302DD18F690094AC1C /* iTunesAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -109,6 +134,29 @@
 			productReference = E51A31A62DCC9F73009043B0 /* iTunesApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E5D7D22F2DD18F690094AC1C /* iTunesAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5D7D2362DD18F690094AC1C /* Build configuration list for PBXNativeTarget "iTunesAppTests" */;
+			buildPhases = (
+				E5D7D22C2DD18F690094AC1C /* Sources */,
+				E5D7D22D2DD18F690094AC1C /* Frameworks */,
+				E5D7D22E2DD18F690094AC1C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E5D7D2352DD18F690094AC1C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				E5D7D2312DD18F690094AC1C /* iTunesAppTests */,
+			);
+			name = iTunesAppTests;
+			packageProductDependencies = (
+			);
+			productName = iTunesAppTests;
+			productReference = E5D7D2302DD18F690094AC1C /* iTunesAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -121,6 +169,10 @@
 				TargetAttributes = {
 					E51A31A52DCC9F73009043B0 = {
 						CreatedOnToolsVersion = 16.3;
+					};
+					E5D7D22F2DD18F690094AC1C = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = E51A31A52DCC9F73009043B0;
 					};
 				};
 			};
@@ -144,12 +196,20 @@
 			projectRoot = "";
 			targets = (
 				E51A31A52DCC9F73009043B0 /* iTunesApp */,
+				E5D7D22F2DD18F690094AC1C /* iTunesAppTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E51A31A42DCC9F73009043B0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5D7D22E2DD18F690094AC1C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -166,7 +226,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E5D7D22C2DD18F690094AC1C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E5D7D2352DD18F690094AC1C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E51A31A52DCC9F73009043B0 /* iTunesApp */;
+			targetProxy = E5D7D2342DD18F690094AC1C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		E51A31BA2DCC9F76009043B0 /* Debug */ = {
@@ -354,6 +429,52 @@
 			};
 			name = Release;
 		};
+		E5D7D2372DD18F690094AC1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DZAU4TTS8S;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.juseong.iTunesAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iTunesApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/iTunesApp";
+			};
+			name = Debug;
+		};
+		E5D7D2382DD18F690094AC1C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DZAU4TTS8S;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.juseong.iTunesAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iTunesApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/iTunesApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -371,6 +492,15 @@
 			buildConfigurations = (
 				E51A31BA2DCC9F76009043B0 /* Debug */,
 				E51A31BB2DCC9F76009043B0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E5D7D2362DD18F690094AC1C /* Build configuration list for PBXNativeTarget "iTunesAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5D7D2372DD18F690094AC1C /* Debug */,
+				E5D7D2382DD18F690094AC1C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iTunesApp/iTunesApp/App/DIContainer.swift
+++ b/iTunesApp/iTunesApp/App/DIContainer.swift
@@ -1,0 +1,42 @@
+//
+//  DIContainer.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import UIKit
+
+final class DIContainer {
+    
+    // MARK: - API Service
+    
+    private let apiService = iTunesApiService()
+    
+    // MARK: - Repository
+    
+    func makeMusicRepository() -> MusicRepository {
+        MusicRepositoryImpl(apiService: apiService)
+    }
+    
+    // MARK: - UseCase
+    
+    func makeFetchHomeMusicUseCase() -> FetchHomeMusicUseCase {
+        FetchHomeMusicUseCase(repository: makeMusicRepository())
+    }
+    
+    // MARK: - ViewModel
+    
+    func makeHomeViewModel() -> HomeViewModel {
+        HomeViewModel(useCase: makeFetchHomeMusicUseCase())
+    }
+    
+    // MARK: - ViewController
+    
+    func makeHomeViewController() -> HomeViewController {
+        HomeViewController(
+            viewModel: makeHomeViewModel(),
+            diContatiner: self
+        )
+    }
+}

--- a/iTunesApp/iTunesApp/App/SceneDelegate.swift
+++ b/iTunesApp/iTunesApp/App/SceneDelegate.swift
@@ -16,7 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = diContainer.makeHomeViewController()
+        let vc = diContainer.makeHomeViewController()
+        window?.rootViewController = UINavigationController(rootViewController: vc)
         window?.makeKeyAndVisible()
     }
 }

--- a/iTunesApp/iTunesApp/App/SceneDelegate.swift
+++ b/iTunesApp/iTunesApp/App/SceneDelegate.swift
@@ -10,14 +10,13 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private let diContainer = DIContainer()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = HomeViewController()
+        window?.rootViewController = diContainer.makeHomeViewController()
         window?.makeKeyAndVisible()
     }
-
 }
-

--- a/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
+++ b/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
@@ -39,9 +39,8 @@ extension MusicResult {
     func toEntity() -> MusicEntity? {
         
         let formatter = ISO8601DateFormatter()
-        
+                
         guard
-            let artworkURL = URL(string: artworkUrl30),
             let trackURL = URL(string: trackViewURL),
             let preview = previewURL,
             let previewURL = URL(string: preview),
@@ -54,7 +53,7 @@ extension MusicResult {
             trackName: trackName,
             artistName: artistName,
             collectionName: collectionName ?? "",
-            artworkURL: artworkURL,
+            artworkURLString: artworkUrl30,
             releaseDate: parsedDate,
             trackURL: trackURL,
             previewURL: previewURL,

--- a/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
+++ b/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
@@ -14,6 +14,7 @@ struct MusicDTO: Decodable {
 
 // MARK: - Result
 struct MusicResult: Decodable {
+    let trackId: Int
     let artistName: String
     let collectionName: String?
     let trackName: String
@@ -24,6 +25,7 @@ struct MusicResult: Decodable {
     let trackTimeMillis: Int?
     
     enum CodingKeys: String, CodingKey {
+        case trackId
         case artistName
         case collectionName
         case trackName
@@ -50,6 +52,7 @@ extension MusicResult {
         }
         
         return .init(
+            id: "\(trackId)",
             trackName: trackName,
             artistName: artistName,
             collectionName: collectionName ?? "",

--- a/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
+++ b/iTunesApp/iTunesApp/Data/DTO/MusicDTO.swift
@@ -1,0 +1,64 @@
+//
+//  MusicDTO.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/11/25.
+//
+
+import Foundation
+
+// MARK: - Welcome
+struct MusicDTO: Decodable {
+    let results: [MusicResult]
+}
+
+// MARK: - Result
+struct MusicResult: Decodable {
+    let artistName: String
+    let collectionName: String?
+    let trackName: String
+    let trackViewURL: String
+    let previewURL: String?
+    let artworkUrl30: String
+    let releaseDate: String
+    let trackTimeMillis: Int?
+    
+    enum CodingKeys: String, CodingKey {
+        case artistName
+        case collectionName
+        case trackName
+        case trackViewURL = "trackViewUrl"
+        case previewURL = "previewUrl"
+        case artworkUrl30
+        case releaseDate
+        case trackTimeMillis
+    }
+}
+
+extension MusicResult {
+    func toEntity() -> MusicEntity? {
+        
+        let formatter = ISO8601DateFormatter()
+        
+        guard
+            let artworkURL = URL(string: artworkUrl30),
+            let trackURL = URL(string: trackViewURL),
+            let preview = previewURL,
+            let previewURL = URL(string: preview),
+            let parsedDate = formatter.date(from: releaseDate)
+        else {
+            return nil // URL 변환 실패 시 전체 무시
+        }
+        
+        return .init(
+            trackName: trackName,
+            artistName: artistName,
+            collectionName: collectionName ?? "",
+            artworkURL: artworkURL,
+            releaseDate: parsedDate,
+            trackURL: trackURL,
+            previewURL: previewURL,
+            durationInSeconds: (trackTimeMillis ?? 0) / 1000
+        )
+    }
+}

--- a/iTunesApp/iTunesApp/Data/RepositoryImpl/MusicRepositoryImpl.swift
+++ b/iTunesApp/iTunesApp/Data/RepositoryImpl/MusicRepositoryImpl.swift
@@ -1,0 +1,22 @@
+//
+//  MusicRepositoryImpl.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import Foundation
+
+final class MusicRepositoryImpl: MusicRepository {
+    
+    private let apiService: iTunesApiService
+    
+    init(apiService: iTunesApiService) {
+        self.apiService = apiService
+    }
+    
+    func fetchMusics(for season: Season) async throws -> [MusicEntity] {
+        let dto = try await apiService.fetchMusics(term: season.queryKeyword)
+        return dto.results.compactMap { $0.toEntity() }
+    }
+}

--- a/iTunesApp/iTunesApp/Data/iTunesApiService.swift
+++ b/iTunesApp/iTunesApp/Data/iTunesApiService.swift
@@ -1,0 +1,44 @@
+//
+//  iTunesApiService.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL       // URL 생성 실패
+    case responseError    // 서버 응답 오류
+    case decodingError    // JSON 디코딩 실패
+}
+
+final class iTunesApiService {
+    
+    func fetchMusics(term: String) async throws -> MusicDTO {
+        var components = URLComponents(string: ITunesAPI.baseURL)
+        components?.queryItems = [
+            URLQueryItem(name: "country", value: ITunesAPI.country),
+            URLQueryItem(name: "media", value: ITunesAPI.Music.media),
+            URLQueryItem(name: "entity", value: ITunesAPI.Music.entity),
+            URLQueryItem(name: "limit", value: ITunesAPI.Music.limit),
+            URLQueryItem(name: "term", value: term)
+        ]
+        
+        guard let url = components?.url else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(MusicDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+}

--- a/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
+++ b/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
@@ -1,0 +1,19 @@
+//
+//  MusicEntity.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/11/25.
+//
+
+import Foundation
+
+struct MusicEntity: Hashable {
+    let trackName: String
+    let artistName: String
+    let collectionName: String
+    let artworkURL: URL
+    let releaseDate: Date
+    let trackURL: URL
+    let previewURL: URL
+    let durationInSeconds: Int
+}

--- a/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
+++ b/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
@@ -11,7 +11,7 @@ struct MusicEntity: Hashable {
     let trackName: String
     let artistName: String
     let collectionName: String
-    let artworkURL: URL
+    let artworkURLString: String
     let releaseDate: Date
     let trackURL: URL
     let previewURL: URL

--- a/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
+++ b/iTunesApp/iTunesApp/Domain/Entity/MusicEntity.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct MusicEntity: Hashable {
+    var id: String
     let trackName: String
     let artistName: String
     let collectionName: String

--- a/iTunesApp/iTunesApp/Domain/Entity/Season.swift
+++ b/iTunesApp/iTunesApp/Domain/Entity/Season.swift
@@ -1,0 +1,19 @@
+//
+//  Season.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+enum Season: Int, CaseIterable {
+    case spring, summer, fall, winter
+    
+    var queryKeyword: String {
+        switch self {
+        case .spring: return "봄"
+        case .summer: return "여름"
+        case .fall: return "가을"
+        case .winter: return "겨울"
+        }
+    }
+}

--- a/iTunesApp/iTunesApp/Domain/Model/SeasonalMusics.swift
+++ b/iTunesApp/iTunesApp/Domain/Model/SeasonalMusics.swift
@@ -1,0 +1,11 @@
+//
+//  SeasonalMusics.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+struct SeasonalMusics {
+    let season: Season
+    let musics: [MusicEntity]
+}

--- a/iTunesApp/iTunesApp/Domain/Repository/MusicRepository.swift
+++ b/iTunesApp/iTunesApp/Domain/Repository/MusicRepository.swift
@@ -1,0 +1,12 @@
+//
+//  MusicRepository.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/10/25.
+//
+
+import Foundation
+
+protocol MusicRepository {
+    func fetchMusics(for season: Season) async throws -> [MusicEntity]
+}

--- a/iTunesApp/iTunesApp/Domain/UseCase/FetchHomeMusicUseCase.swift
+++ b/iTunesApp/iTunesApp/Domain/UseCase/FetchHomeMusicUseCase.swift
@@ -1,0 +1,36 @@
+//
+//  FetchHomeMusicUseCase.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/10/25.
+//
+
+import Foundation
+
+final class FetchHomeMusicUseCase {
+    private let repository: MusicRepository
+    
+    init(repository: MusicRepository) {
+        self.repository = repository
+    }
+    
+    func execute() async -> Result<[SeasonalMusics], Error> {
+        do {
+            async let springMusics = await repository.fetchMusics(for: .spring)
+            async let summerMusics = await repository.fetchMusics(for: .summer)
+            async let fallMusics = await repository.fetchMusics(for: .fall)
+            async let winterMusics = await repository.fetchMusics(for: .winter)
+
+            let seasonalMusics: [SeasonalMusics] = try await [
+                .init(season: Season.spring, musics: springMusics),
+                .init(season: Season.summer, musics: summerMusics),
+                .init(season: Season.fall, musics: fallMusics),
+                .init(season: Season.winter, musics: winterMusics)
+            ]
+
+            return .success(seasonalMusics)
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
@@ -77,21 +77,36 @@ class MusicCardCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    func update(with music: MusicEntity, _ index: Int) {
+    
+    private func updateLabels(with music: MusicEntity, index: Int) {
         trackNameLabel.text = music.trackName
         artistNameLabel.text = music.artistName
-        numberLabel.text = "\(index)"
-        
-        let highResArtworkURLString = music.artworkURLString.replacingOccurrences(of: "30x30", with: "500x500")
-        guard let artworkURL = URL(string: highResArtworkURLString) else { return }
-        
+        numberLabel.text = "\(calculateDisplayIndex(from: index))"
+    }
+
+    private func calculateDisplayIndex(from index: Int) -> Int {
+        if index < 3 {
+            return index + 8
+        } else if index > 12 {
+            return index - 12
+        } else {
+            return index - 2
+        }
+    }
+
+    private func updateAlbumImage(with artworkURLString: String) {
+        let highResURLString = artworkURLString.replacingOccurrences(of: "30x30", with: "500x500")
+        guard let url = URL(string: highResURLString) else { return }
+
         albumImageView.kf.setImage(
-            with: artworkURL,
-            options: [
-                .transition(.fade(0.25))
-            ]
+            with: url,
+            options: [.transition(.fade(0.25))]
         )
+    }
+
+    func update(with music: MusicEntity, _ index: Int) {
+        updateLabels(with: music, index: index)
+        updateAlbumImage(with: music.artworkURLString)
     }
 }
 

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
@@ -1,0 +1,40 @@
+//
+//  MusicCardCell.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import UIKit
+
+class MusicCardCell: UICollectionViewCell {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension MusicCardCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        contentView.backgroundColor = .red
+    }
+    
+    func setHierarchy() {
+        
+    }
+    
+    func setConstraints() {
+        
+    }
+}

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicCardCell.swift
@@ -6,35 +6,140 @@
 //
 
 import UIKit
+import SnapKit
+import Kingfisher
 
 class MusicCardCell: UICollectionViewCell {
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 12
+        return view
+    }()
+    
+    private let albumImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    
+    private let labelContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .secondarySystemBackground
+        return view
+    }()
+    
+    private let numberLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 25, weight: .bold)
+        label.textColor = .label
+        label.textAlignment = .center
+        label.text = "1"
+        return label
+    }()
+    
+    private lazy var labelStackView: UIStackView = {
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                trackNameLabel,
+                artistNameLabel
+            ]
+        )
+        stackView.axis = .vertical
+        stackView.spacing = 5
+        return stackView
+    }()
+    
+    private let trackNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .label
+        return label
+    }()
+    
+    private let artistNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .systemGray
+        return label
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
     }
     
+    override func prepareForReuse() {
+        albumImageView.image = nil
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(with music: MusicEntity, _ index: Int) {
+        trackNameLabel.text = music.trackName
+        artistNameLabel.text = music.artistName
+        numberLabel.text = "\(index)"
+        
+        let highResArtworkURLString = music.artworkURLString.replacingOccurrences(of: "30x30", with: "500x500")
+        guard let artworkURL = URL(string: highResArtworkURLString) else { return }
+        
+        albumImageView.kf.setImage(
+            with: artworkURL,
+            options: [
+                .transition(.fade(0.25))
+            ]
+        )
     }
 }
 
 private extension MusicCardCell {
     func configure() {
-        setAttributes()
         setHierarchy()
         setConstraints()
     }
-    
-    func setAttributes() {
-        contentView.backgroundColor = .red
-    }
-    
-    func setHierarchy() {
         
+    func setHierarchy() {
+        addSubview(containerView)
+        
+        [
+            albumImageView,
+            labelContainerView
+        ].forEach { containerView.addSubview($0) }
+        
+        [
+            numberLabel,
+            labelStackView
+        ].forEach { labelContainerView.addSubview($0) }
     }
     
     func setConstraints() {
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
+        albumImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        labelContainerView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(70)
+        }
+        
+        numberLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(10)
+            $0.size.equalTo(40)
+            $0.centerY.equalToSuperview()
+        }
+        
+        labelStackView.snp.makeConstraints {
+            $0.leading.equalTo(numberLabel.snp.trailing).offset(10)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
     }
 }

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
@@ -6,8 +6,74 @@
 //
 
 import UIKit
+import SnapKit
+import Kingfisher
 
 class MusicRowCell: UICollectionViewCell {
+    
+    // MARK: - UI Components
+    
+    private lazy var horizontalStackView: UIStackView = {
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                albumImageView,
+                verticalStackView
+            ]
+        )
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 10
+        return stackView
+    }()
+    
+    private let albumImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        return imageView
+    }()
+    
+    private lazy var verticalStackView: UIStackView = {
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                trackNameLabel,
+                artistNameLabel,
+                albumNameLabel
+            ]
+        )
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.distribution = .fillProportionally
+        return stackView
+    }()
+    
+    private let trackNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        return label
+    }()
+    
+    private let artistNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .regular)
+        return label
+    }()
+    
+    private let albumNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = .systemGray
+        return label
+    }()
+    
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .separator
+        return view
+    }()
+    
+    // MARK: - Initailizer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -17,24 +83,59 @@ class MusicRowCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - Life Cycle
+    
+    override func prepareForReuse() {
+        albumImageView.image = nil
+    }
+    
+    // MARK: - Update UI
+    
+    func update(with music: MusicEntity, isLast: Bool) {
+        albumNameLabel.text = music.collectionName
+        trackNameLabel.text = music.trackName
+        artistNameLabel.text = music.artistName
+        separatorView.isHidden = isLast
+        
+        let highResArtworkURLString = music.artworkURLString.replacingOccurrences(of: "30x30", with: "100x100")
+        guard let artworkURL = URL(string: highResArtworkURLString) else { return }
+        
+        albumImageView.kf.setImage(
+            with: artworkURL,
+            options: [
+                .transition(.fade(0.25))
+            ]
+        )
+    }
 }
+
+// MARK: - Cell Configure
 
 private extension MusicRowCell {
     func configure() {
-        setAttributes()
         setHierarchy()
         setConstraints()
     }
     
-    func setAttributes() {
-        contentView.backgroundColor = .blue
-    }
-    
     func setHierarchy() {
-        
+        [horizontalStackView, separatorView].forEach { addSubview($0) }
     }
     
     func setConstraints() {
+        horizontalStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
+        albumImageView.snp.makeConstraints {
+            $0.height.equalTo(verticalStackView.snp.height)
+            $0.width.equalTo(albumImageView.snp.height)
+        }
+        
+        separatorView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(0.5)
+        }
     }
 }

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
@@ -31,6 +31,8 @@ class MusicRowCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = 8
+        imageView.layer.borderColor = UIColor.separator.cgColor
+        imageView.layer.borderWidth = 0.5
         return imageView
     }()
     
@@ -50,19 +52,19 @@ class MusicRowCell: UICollectionViewCell {
     
     private let trackNameLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 14, weight: .bold)
+        label.font = .systemFont(ofSize: 16, weight: .bold)
         return label
     }()
     
     private let artistNameLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 13, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .regular)
         return label
     }()
     
     private let albumNameLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .regular)
         label.textColor = .systemGray
         return label
     }()
@@ -92,7 +94,7 @@ class MusicRowCell: UICollectionViewCell {
     
     // MARK: - Update UI
     
-    func update(with music: MusicEntity, isLast: Bool) {
+    func update(with music: MusicEntity, _ isLast: Bool) {
         albumNameLabel.text = music.collectionName
         trackNameLabel.text = music.trackName
         artistNameLabel.text = music.artistName
@@ -133,7 +135,7 @@ private extension MusicRowCell {
         }
         
         separatorView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalTo(verticalStackView)
             $0.bottom.equalToSuperview()
             $0.height.equalTo(0.5)
         }

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/MusicRowCell.swift
@@ -1,0 +1,40 @@
+//
+//  MusicRowCell.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import UIKit
+
+class MusicRowCell: UICollectionViewCell {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension MusicRowCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        contentView.backgroundColor = .blue
+    }
+    
+    func setHierarchy() {
+        
+    }
+    
+    func setConstraints() {
+        
+    }
+}

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
@@ -10,6 +10,26 @@ import SnapKit
 
 final class SectionHeaderView: UICollectionReusableView {
     
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 3
+        return stackView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        return label
+    }()
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .systemGray
+        return label
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -18,25 +38,39 @@ final class SectionHeaderView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func update(with season: Season) {
+        switch season {
+        case .spring:
+            titleLabel.text = "봄 Best"
+            descriptionLabel.text = "봄에 어울리는 음악 Best 5"
+        case .summer:
+            titleLabel.text = "여름"
+            descriptionLabel.text = "여름에 어울리는 음악"
+        case .fall:
+            titleLabel.text = "가을"
+            descriptionLabel.text = "가을에 어울리는 음악"
+        case .winter:
+            titleLabel.text = "겨울"
+            descriptionLabel.text = "겨울에 어울리는 음악"
+        }
+    }
 }
 
 private extension SectionHeaderView {
     func configure() {
-        setAttributes()
         setHierarchy()
         setConstraints()
     }
     
-    func setAttributes() {
-        backgroundColor = .green
-    }
-    
     func setHierarchy() {
-        
+        addSubview(stackView)
     }
     
     func setConstraints() {
-        
+        stackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
     }
 }
-

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
@@ -19,7 +19,7 @@ final class SectionHeaderView: UICollectionReusableView {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.font = .systemFont(ofSize: 22, weight: .bold)
         return label
     }()
     
@@ -43,7 +43,7 @@ final class SectionHeaderView: UICollectionReusableView {
         switch season {
         case .spring:
             titleLabel.text = "봄 Best"
-            descriptionLabel.text = "봄에 어울리는 음악 Best 5"
+            descriptionLabel.text = "봄에 어울리는 음악 Best 10"
         case .summer:
             titleLabel.text = "여름"
             descriptionLabel.text = "여름에 어울리는 음악"

--- a/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/Components/SectionHeaderView.swift
@@ -1,0 +1,42 @@
+//
+//  SectionHeaderView.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class SectionHeaderView: UICollectionReusableView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension SectionHeaderView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        backgroundColor = .green
+    }
+    
+    func setHierarchy() {
+        
+    }
+    
+    func setConstraints() {
+        
+    }
+}
+

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
@@ -25,7 +25,7 @@ class HomeView: UIView {
             frame: .zero,
             collectionViewLayout: self.createCollectionViewLayout()
         )
-        collectionView.backgroundColor = .secondarySystemBackground
+        collectionView.backgroundColor = .systemBackground
         collectionView.showsVerticalScrollIndicator = false
         return collectionView
     }()
@@ -99,7 +99,7 @@ class HomeView: UIView {
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.9),
-            heightDimension: .fractionalWidth(0.9)
+            heightDimension: .fractionalWidth(0.7)
         )
         
         let group = NSCollectionLayoutGroup.horizontal(
@@ -125,7 +125,7 @@ class HomeView: UIView {
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.9),
-            heightDimension: .absolute(200)
+            heightDimension: .absolute(240)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
@@ -144,13 +144,13 @@ class HomeView: UIView {
     // MARK: - Configure Datasource
     
     private func configureDataSource() {
-        let springCellRegistration = UICollectionView.CellRegistration<MusicCardCell, Item> { cell, _, item in
-            
+        let springCellRegistration = UICollectionView.CellRegistration<MusicCardCell, Item> { cell, indexPath, item in
+            cell.update(with: item, indexPath.row + 1)
         }
 
         let defaultCellRegistration = UICollectionView.CellRegistration<MusicRowCell, Item> { cell, indexPath, item in
             let isGroupLast = (indexPath.item + 1) % 3 == 0
-            cell.update(with: item, isLast: isGroupLast)
+            cell.update(with: item, isGroupLast)
         }
                 
         let headerRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>(
@@ -215,7 +215,7 @@ private extension HomeView {
     }
     
     func setAttributes() {
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = .systemBackground
     }
     
     func setHierarchy() {

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
@@ -1,0 +1,228 @@
+//
+//  HomeView.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import UIKit
+
+class HomeView: UIView {
+    
+    // MARK: - Section & Item
+    
+    typealias Section = Season
+    typealias Item = MusicEntity
+    
+    // MARK: - Properties
+    
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
+    
+    // MARK: - UI Components
+    
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: self.createCollectionViewLayout()
+        )
+        collectionView.backgroundColor = .secondarySystemBackground
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    // MARK: - Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        configureDataSource()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - CollectionView Layout
+    
+    private func createCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout(
+            sectionProvider: { [weak self] (index, env) -> NSCollectionLayoutSection? in
+                guard let self else { return nil }
+                guard let section = Section(rawValue: index) else { return nil }
+                return self.makeSection(for: section)
+            },
+            configuration: {
+                let config = UICollectionViewCompositionalLayoutConfiguration()
+                config.interSectionSpacing = 20
+                return config
+            }()
+        )
+        return layout
+    }
+    
+    private func makeSection(for section: Section) -> NSCollectionLayoutSection {
+        let header = makeHeaderItemLayout()
+        let layoutSection: NSCollectionLayoutSection
+        
+        switch section {
+        case .spring:
+            layoutSection = springSectionLayout()
+        case .summer, .fall, .winter:
+            layoutSection = defaultSeasonSectionLayout()
+        }
+        
+        layoutSection.boundarySupplementaryItems = [header]
+        return layoutSection
+    }
+    
+    // MARK: - Header Layout
+    
+    private func makeHeaderItemLayout() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        return header
+    }
+    
+    // MARK: - Spring Section Layout
+    
+    private func springSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.8),
+            heightDimension: .fractionalWidth(0.8)
+        )
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.interGroupSpacing = 20
+
+        return section
+    }
+    
+    // MARK: - Default Season Layout
+    
+    private func defaultSeasonSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(0.33)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.8),
+            heightDimension: .fractionalWidth(0.8)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(8)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.interGroupSpacing = 20
+
+        return section
+    }
+    
+    // MARK: - Configure Datasource
+    
+    private func configureDataSource() {
+        let springCellRegistration = UICollectionView.CellRegistration<MusicCardCell, Item> { cell, _, item in
+            
+        }
+
+        let defaultCellRegistration = UICollectionView.CellRegistration<MusicRowCell, Item> { cell, _, item in
+            
+        }
+        
+        let headerRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>(
+            elementKind: UICollectionView.elementKindSectionHeader
+        ) { header, _, indexPath in
+            
+        }
+
+        dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
+            let section = Section.allCases[indexPath.section]
+            
+            switch section {
+            case .spring:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: springCellRegistration,
+                    for: indexPath,
+                    item: item
+                )
+            case .summer, .fall, .winter:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: defaultCellRegistration,
+                    for: indexPath,
+                    item: item
+                )
+            }
+        }
+
+        dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(
+                using: headerRegistration,
+                for: indexPath
+            )
+        }
+    }
+    
+    // MARK: - SnapShot
+    
+    func applySnapshot(with seasonalMusics: [SeasonalMusics]) {
+        guard !seasonalMusics.isEmpty else { return }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections(Section.allCases)
+
+        seasonalMusics.forEach { seasonalMusic in
+            snapshot.appendItems(seasonalMusic.musics, toSection: seasonalMusic.season)
+        }
+
+        dataSource?.apply(snapshot, animatingDifferences: true)
+    }
+}
+
+// MARK: - View Configure
+
+private extension HomeView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        backgroundColor = .secondarySystemBackground
+    }
+    
+    func setHierarchy() {
+        addSubview(collectionView)
+    }
+    
+    func setConstraints() {
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
+            $0.bottom.equalToSuperview()
+        }
+    }
+}

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeView.swift
@@ -98,8 +98,8 @@ class HomeView: UIView {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(0.8),
-            heightDimension: .fractionalWidth(0.8)
+            widthDimension: .fractionalWidth(0.9),
+            heightDimension: .fractionalWidth(0.9)
         )
         
         let group = NSCollectionLayoutGroup.horizontal(
@@ -109,7 +109,7 @@ class HomeView: UIView {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPagingCentered
-        section.interGroupSpacing = 20
+        section.interGroupSpacing = 10
 
         return section
     }
@@ -119,24 +119,24 @@ class HomeView: UIView {
     private func defaultSeasonSectionLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(0.33)
+            heightDimension: .fractionalHeight(1.0 / 3.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(0.8),
-            heightDimension: .fractionalWidth(0.8)
+            widthDimension: .fractionalWidth(0.9),
+            heightDimension: .absolute(200)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
             repeatingSubitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(8)
+        group.interItemSpacing = .fixed(10)
 
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPagingCentered
-        section.interGroupSpacing = 20
+        section.interGroupSpacing = 10
 
         return section
     }
@@ -148,19 +148,23 @@ class HomeView: UIView {
             
         }
 
-        let defaultCellRegistration = UICollectionView.CellRegistration<MusicRowCell, Item> { cell, _, item in
-            
+        let defaultCellRegistration = UICollectionView.CellRegistration<MusicRowCell, Item> { cell, indexPath, item in
+            let isGroupLast = (indexPath.item + 1) % 3 == 0
+            cell.update(with: item, isLast: isGroupLast)
         }
-        
+                
         let headerRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>(
             elementKind: UICollectionView.elementKindSectionHeader
         ) { header, _, indexPath in
-            
+            guard let section = Section(rawValue: indexPath.section) else { return }
+            header.update(with: section)
         }
 
         dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
-            let section = Section.allCases[indexPath.section]
-            
+            guard let section = Section(rawValue: indexPath.section) else {
+                return UICollectionViewCell()
+            }
+
             switch section {
             case .spring:
                 return collectionView.dequeueConfiguredReusableCell(

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
@@ -17,6 +17,10 @@ final class HomeViewController: UIViewController {
     private let diContaitner: DIContainer
     private let viewModel: HomeViewModel
     
+    // MARK: - UI Components
+    
+    private let homeView = HomeView()
+    
     // MARK: - Initailizer
     
     init(viewModel: HomeViewModel, diContatiner: DIContainer) {
@@ -30,6 +34,10 @@ final class HomeViewController: UIViewController {
     }
     
     // MARK: - View Life Cycle
+    
+    override func loadView() {
+        self.view = homeView
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -63,9 +71,11 @@ private extension HomeViewController {
     func setBindings() {
         viewModel.state
             .subscribe { [weak self] state in
+                guard let self else { return }
+                
                 switch state {
                 case .homeScreenMusics(let musics):
-                    print(musics)
+                    self.homeView.applySnapshot(with: musics)
                 case .networkError(let error):
                     print(error)
                 }

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
@@ -6,15 +6,70 @@
 //
 
 import UIKit
+import RxSwift
+import RxRelay
 
-class HomeViewController: UIViewController {
-
+final class HomeViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let disposebag = DisposeBag()
+    private let diContaitner: DIContainer
+    private let viewModel: HomeViewModel
+    
+    // MARK: - Initailizer
+    
+    init(viewModel: HomeViewModel, diContatiner: DIContainer) {
+        self.viewModel = viewModel
+        self.diContaitner = diContatiner
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        view.backgroundColor = .red
+        configure()
+        viewModel.action.accept(.viewDidLoad)
     }
-
-
 }
 
+// MARK: - ViewController Configure
+
+private extension HomeViewController {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+        setBindings()
+    }
+    
+    func setAttributes() {
+        
+    }
+    
+    func setHierarchy() {
+        
+    }
+    
+    func setConstraints() {
+        
+    }
+    
+    func setBindings() {
+        viewModel.state
+            .subscribe { [weak self] state in
+                switch state {
+                case .homeScreenMusics(let musics):
+                    print(musics)
+                case .networkError(let error):
+                    print(error)
+                }
+            }
+            .disposed(by: disposebag)
+    }
+}

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 import RxSwift
-import RxRelay
+import RxCocoa
 
 final class HomeViewController: UIViewController {
     
@@ -70,9 +70,9 @@ private extension HomeViewController {
     
     func setBindings() {
         viewModel.state
-            .subscribe { [weak self] state in
+            .asDriver()
+            .drive { [weak self] state in
                 guard let self else { return }
-                
                 switch state {
                 case .homeScreenMusics(let musics):
                     self.homeView.applySnapshot(with: musics)

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeViewController.swift
@@ -21,6 +21,8 @@ final class HomeViewController: UIViewController {
     
     private let homeView = HomeView()
     
+    private let searchController = UISearchController(searchResultsController: nil)
+    
     // MARK: - Initailizer
     
     init(viewModel: HomeViewModel, diContatiner: DIContainer) {
@@ -51,21 +53,18 @@ final class HomeViewController: UIViewController {
 private extension HomeViewController {
     func configure() {
         setAttributes()
-        setHierarchy()
-        setConstraints()
         setBindings()
     }
     
     func setAttributes() {
-        
-    }
-    
-    func setHierarchy() {
-        
-    }
-    
-    func setConstraints() {
-        
+        navigationItem.title = "Music"
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .always
+
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+
+        searchController.searchBar.placeholder = "영화, 팟캐스트 검색"
     }
     
     func setBindings() {

--- a/iTunesApp/iTunesApp/Presentation/Home/HomeViewModel.swift
+++ b/iTunesApp/iTunesApp/Presentation/Home/HomeViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  HomeViewModel.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class HomeViewModel {
+    
+    // MARK: - State & Action
+    
+    enum State {
+        case homeScreenMusics([SeasonalMusics])
+        case networkError(Error)
+    }
+    
+    enum Action {
+        case viewDidLoad
+    }
+    
+    // MARK: - Properties
+    
+    private var disposeBag = DisposeBag()
+    
+    let state = BehaviorRelay<State>(value: .homeScreenMusics([]))
+    let action = PublishRelay<Action>()
+    
+    private let useCase: FetchHomeMusicUseCase
+    
+    // MARK: - Initailizer
+    
+    init(useCase: FetchHomeMusicUseCase) {
+        self.useCase = useCase
+        bind()
+    }
+    
+    // MARK: - Bind
+    
+    private func bind() {
+        action
+            .subscribe { [weak self] action in
+                guard let self else { return }
+                
+                switch action {
+                case .viewDidLoad:
+                    Task { await self.fetchSeosonalMusics() }
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    // MARK: - Method
+    
+    private func fetchSeosonalMusics() async {
+        let result = await useCase.execute()
+        
+        switch result {
+        case .success(let musics):
+            state.accept(.homeScreenMusics(musics))
+        case .failure(let error):
+            state.accept(.networkError(error))
+        }
+    }
+}

--- a/iTunesApp/iTunesApp/Utils/Constants.swift
+++ b/iTunesApp/iTunesApp/Utils/Constants.swift
@@ -1,0 +1,19 @@
+//
+//  Constants.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import Foundation
+
+enum ITunesAPI {
+    static let baseURL = "https://itunes.apple.com/search"
+    static let country = Locale.current.region?.identifier.lowercased() ?? "kr"
+    
+    enum Music {
+        static let media = "music"
+        static let entity = "musicTrack"
+        static let limit = "30"
+    }
+}

--- a/iTunesApp/iTunesAppTests/FetchHomeMusicUseCaseTests.swift
+++ b/iTunesApp/iTunesAppTests/FetchHomeMusicUseCaseTests.swift
@@ -1,0 +1,27 @@
+//
+//  FetchHomeMusicUseCaseTests.swift
+//  iTunesAppTests
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import XCTest
+@testable import iTunesApp
+
+final class FetchHomeMusicUseCaseTests: XCTestCase {
+
+    func test_execute_returnsMockedSeasonalMusics() async {
+        let useCase = FetchHomeMusicUseCase(repository: MockMusicRepository())
+        let result = await useCase.execute()
+
+        switch result {
+        case .success(let seasonalMusics):
+            XCTAssertEqual(seasonalMusics.count, 4)
+            XCTAssertEqual(seasonalMusics.first(where: { $0.season == .spring })?.musics.count, 1)
+            XCTAssertEqual(seasonalMusics.first(where: { $0.season == .summer })?.musics.count, 1)
+            XCTAssertEqual(seasonalMusics.first(where: { $0.season == .fall })?.musics.count, 0)
+        case .failure:
+            XCTFail("Should not fail")
+        }
+    }
+}

--- a/iTunesApp/iTunesAppTests/Mock/MockMusicRepository.swift
+++ b/iTunesApp/iTunesAppTests/Mock/MockMusicRepository.swift
@@ -1,0 +1,44 @@
+//
+//  MockMusicRepository.swift
+//  iTunesApp
+//
+//  Created by 박주성 on 5/12/25.
+//
+
+import Foundation
+@testable import iTunesApp
+
+final class MockMusicRepository: MusicRepository {
+    private let mockData: [Season: [MusicEntity]] = [
+        .spring: [
+            MusicEntity(
+                trackName: "봄 노래",
+                artistName: "벚꽃 가수",
+                collectionName: "봄 앨범",
+                artworkURL: URL(string: "https://example.com")!,
+                releaseDate: Date(),
+                trackURL: URL(string: "https://example.com")!,
+                previewURL: URL(string: "https://example.com")!,
+                durationInSeconds: 180
+            )
+        ],
+        .summer: [
+            MusicEntity(
+                trackName: "여름 노래",
+                artistName: "바다 가수",
+                collectionName: "여름 앨범",
+                artworkURL: URL(string: "https://example.com")!,
+                releaseDate: Date(),
+                trackURL: URL(string: "https://example.com")!,
+                previewURL: URL(string: "https://example.com")!,
+                durationInSeconds: 200
+            )
+        ],
+        .fall: [],
+        .winter: []
+    ]
+
+    func fetchMusics(for season: Season) async -> [MusicEntity] {
+        return mockData[season] ?? []
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed: #1 

## 📌 변경 사항 및 이유
- 홈 화면 UI 구성
  - `MusicCardCell`, `MusicRowCell`, `HeaderView`의 UI 구성 및 데이터 바인딩
  - `SearchController` 홈 화면에 적용
- Compositional Layout 기반으로 홈 화면 섹션을 구성
  - 봄(Spring) 섹션은 캐러셀 형태로, 나머지 계절은 리스트 형태로 보여지도록 설정
- 봄 섹션에 무한 스크롤 기능을 추가하여 UX 개선
  - 앞뒤에 더미 아이템을 복제하여 자연스럽게 순환되도록 구성

## 📌 PR Point
- `visibleItemsInvalidationHandler`를 활용한 캐러셀 무한스크롤 구현
- `DiffableDataSource` 사용 시 동일 데이터 복제에 따른 `Hashable` 충돌을 방지하기 위해 ID 재정의 방식을 사용

## 📌스크린샷
| 라이트 모드                                  | 다크 모드                                  |
|-----------------------------------------------|--------------------------------------------|
| <img src="https://github.com/user-attachments/assets/b0e2f90d-e57a-490c-9833-34919aa8f340" width="250" /> | <img src="https://github.com/user-attachments/assets/a64db85a-902f-4e27-9af7-536a80c0be35" width="250" /> |